### PR TITLE
Adding accessibility refresh to version 5.3

### DIFF
--- a/Content/BB-Chapter-12-WordPress-Matures.md
+++ b/Content/BB-Chapter-12-WordPress-Matures.md
@@ -19,7 +19,7 @@ As of 5.2, PHP version 5.6.20 became the minimum version supported by WordPress.
 
 ![](https://i0.wp.com/wordpress.org/news/files/2019/11/5.3-album-cover.png?w=1440&ssl=1)
 
-The third update for 2019 was [5.3, Kirk](https://wordpress.org/news/2019/11/kirk/), led by [Matt Mullenweg](https://ma.tt/), [Francesca Marano](https://profiles.wordpress.org/francina/), and [David Baumwald](https://profiles.wordpress.org/davidbaumwald). It included a new default theme, Twenty Twenty, designed for the block editor, further tweaks to the Site Health features, and full support for PHP 7.4.
+The third update for 2019 was [5.3, Kirk](https://wordpress.org/news/2019/11/kirk/), led by [Matt Mullenweg](https://ma.tt/), [Francesca Marano](https://profiles.wordpress.org/francina/), and [David Baumwald](https://profiles.wordpress.org/davidbaumwald). It included a new default theme, Twenty Twenty, designed for the block editor, further tweaks to the Site Health features, a refresh of the admin interface for better accessibility, and full support for PHP 7.4.
 
 ![](https://i0.wp.com/themes.svn.wordpress.org/twentytwenty/2.2/screenshot.png?w=1144&strip=all)
 


### PR DESCRIPTION
This was a very important project for the WordPress accessibility team and brought better accessibility on the whole admin interface. Also worth noting that several core team leads were against this change, so as the 5.3 accessibility release lead I had to defend that change for several weeks before it finally gets merged in Core. At the end, these changes are still here in WordPress admin, they provide better accessibility for everyone and WordPress has a better accessibility compliance now :) 

For the record: 
- Here is the dev note: https://make.wordpress.org/core/2019/10/18/noteworthy-admin-css-changes-in-wordpress-5-3/
- Here is the tests we had to put together to defend this change: https://make.wordpress.org/core/2019/10/18/noteworthy-admin-css-changes-in-wordpress-5-3/