### PR TITLE
Add themes and plugins auto-updates in 5.5

### DIFF
--- a/Content/BB-Chapter-3-Plugging-into-plugins.md
+++ b/Content/BB-Chapter-3-Plugging-into-plugins.md
@@ -69,7 +69,7 @@ There was [extensive discussion](https://make.wordpress.org/core/2020/11/10/wp5-
 
 WordPress shared [instructions for disabling](https://make.wordpress.org/core/2013/10/25/the-definitive-guide-to-disabling-auto-updates-in-wordpress-3-7/) auto updates and plugins were developed to make it easier. However, Andrew Nacin wrote in his instructions for sabotaging the auto updates, “I’d argue that ‘I don’t want them’ is not a compelling reason for disabling updates. If you don’t keep your site up to date, you are making the web a less safe place for you and everyone who visits your website.”
 
-Site owners got the chance to opt into auto updates for major core versions with 5.6 in 2020.
+Site owners got the chance to opt into auto updates for plugins and themes with 5.5, and for major core versions with 5.6 in 2020.
 
 If core security is involved and the site owner doesn’t take the necessary steps, the WordPress servers will instruct the website to update itself. This is done for core updates but also for some plugins.
 


### PR DESCRIPTION
Just wanted to complete the current sentence which is only mentioning core auto-updates. For the record the general project of core, plugins and themes auto-updates started in 5.5 and was achieved in 5.6.

This project was conducted via a feature plugin I created: WP Auto-updates (https://github.com/WordPress/wp-autoupdates). It was one of the 4 main goals for 2020 identified by Matt, and I focused most of my 2020 Core work on this, so it would be nice to not forget about plugins and themes auto-updates :) thanks!